### PR TITLE
New comment on bread-pricing from Another Matt

### DIFF
--- a/comments/bread-pricing/entry1636465124235-miug8pz89i.json
+++ b/comments/bread-pricing/entry1636465124235-miug8pz89i.json
@@ -1,0 +1,8 @@
+{
+  "comment": "This is really clever. It reminds me of The Big Mac Index (https://www.economist.com/big-mac-index) that is used to estimate real inflation across the world, but it's more accessible as MacDonald's probably isn't in every country. Every country probably has bread though.\n\nI love that you not only considered this but implemented it and made it real.",
+  "email": "8d12ad160cc20162a35cd6fa63cdeae3",
+  "name": "Another Matt",
+  "subdir": "bread-pricing",
+  "_id": "1636465124235-miug8pz89i",
+  "date": 1636465124235
+}


### PR DESCRIPTION
New comment on `bread-pricing`:

```
{
  "name": "Another Matt",
  "message": "This is really clever. It reminds me of The Big Mac Index (https://www.economist.com/big-mac-index) that is used to estimate real inflation across the world, but it's more accessible as MacDonald's probably isn't in every country. Every country probably has bread though.\n\nI love that you not only considered this but implemented it and made it real.",
  "date": 1636465124235
}
```