### PR TITLE
New comment on fall-update-2021 from Brad Cobb

### DIFF
--- a/comments/fall-update-2021/entry1637673140879-ci5itf1arr.json
+++ b/comments/fall-update-2021/entry1637673140879-ci5itf1arr.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Same! I WAS a $45/yr YNABer since 2016 and pulled the plug shortly after they announced the increase. In recent years I have had more and more trouble importing transactions and needing to re-authorize each time in YNAB. I've been using Buckets for a couple of weeks now and find importing .csv files from my banks to be a pretty simple and overall more reliable process than YNAB. It is really nice that when importing the transactions, it only recognizes new transactions and only imports those. \n\nLooking forward to the mobile app and becoming a Bucket-er!",
+  "email": null,
+  "name": "Brad Cobb",
+  "subdir": "fall-update-2021",
+  "_id": "1637673140879-ci5itf1arr",
+  "date": 1637673140879
+}


### PR DESCRIPTION
New comment on `fall-update-2021`:

```
{
  "name": "Brad Cobb",
  "message": "Same! I WAS a $45/yr YNABer since 2016 and pulled the plug shortly after they announced the increase. In recent years I have had more and more trouble importing transactions and needing to re-authorize each time in YNAB. I've been using Buckets for a couple of weeks now and find importing .csv files from my banks to be a pretty simple and overall more reliable process than YNAB. It is really nice that when importing the transactions, it only recognizes new transactions and only imports those. \n\nLooking forward to the mobile app and becoming a Bucket-er!",
  "date": 1637673140879
}
```