### PR TITLE
New comment on bread-pricing from amanda

### DIFF
--- a/comments/bread-pricing/entry1639798903750-im59ygm6bir.json
+++ b/comments/bread-pricing/entry1639798903750-im59ygm6bir.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Sorry for late reply.\n\nThe references you mentioned is correct, but for the biggest cities i.e Jakarta (Capital), Surabaya (2nd largest city). Like you said, Indonesia is a very diverse country, so Govt always need to deal with these issues case by case.\n\nAlso, why using the white bread as a metric isn't a good choice (thus why I am writing all of these)... because Indonesians don't eat bread, they eat rice. With 500g of white bread, average 4-persons family can only eat for 1 day. With 500g of white bread-worth of rice, they can eat for a two-three whole days. Here's an official metric from the govt for rice: https://hargapangan.id/tabel-harga/pedagang-besar/daerah\n\nIndonesia as a whole, aggregated, have very low income, even lower than the neighbor Malaysia (which have lower Bucket pricing). Data taken from official govt here: https://www.bps.go.id/indicator/19/1521/1/rata-rata-upah-gaji.html\n\nWhile I can totally understand where you're coming from (universal metric using white bread), unfortunately for this specific Indonesia case it's way off the mark.\n\nI apologize for all my posts, I never meant to complaint, I have no bad intention.",
+  "email": null,
+  "name": "amanda",
+  "subdir": "bread-pricing",
+  "_id": "1639798903750-im59ygm6bir",
+  "date": 1639798903750
+}


### PR DESCRIPTION
New comment on `bread-pricing`:

```
{
  "name": "amanda",
  "message": "Sorry for late reply.\n\nThe references you mentioned is correct, but for the biggest cities i.e Jakarta (Capital), Surabaya (2nd largest city). Like you said, Indonesia is a very diverse country, so Govt always need to deal with these issues case by case.\n\nAlso, why using the white bread as a metric isn't a good choice (thus why I am writing all of these)... because Indonesians don't eat bread, they eat rice. With 500g of white bread, average 4-persons family can only eat for 1 day. With 500g of white bread-worth of rice, they can eat for a two-three whole days. Here's an official metric from the govt for rice: https://hargapangan.id/tabel-harga/pedagang-besar/daerah\n\nIndonesia as a whole, aggregated, have very low income, even lower than the neighbor Malaysia (which have lower Bucket pricing). Data taken from official govt here: https://www.bps.go.id/indicator/19/1521/1/rata-rata-upah-gaji.html\n\nWhile I can totally understand where you're coming from (universal metric using white bread), unfortunately for this specific Indonesia case it's way off the mark.\n\nI apologize for all my posts, I never meant to complaint, I have no bad intention.",
  "date": 1639798903750
}
```