### PR TITLE
New comment on december-update from Matt

### DIFF
--- a/comments/december-update/entry1672668204368-72zevq4osqd.json
+++ b/comments/december-update/entry1672668204368-72zevq4osqd.json
@@ -1,0 +1,8 @@
+{
+  "comment": "The unsupported Android devices is unintentional. I think I accidentally set the target ABI version too high. I'll try to fix this on the next release.",
+  "email": "3a760317157c33e6b977df8e35ae857d",
+  "name": "Matt",
+  "subdir": "december-update",
+  "_id": "1672668204368-72zevq4osqd",
+  "date": 1672668204368
+}


### PR DESCRIPTION
New comment on `december-update`:

```
{
  "name": "Matt",
  "message": "The unsupported Android devices is unintentional. I think I accidentally set the target ABI version too high. I'll try to fix this on the next release.",
  "date": 1672668204368
}
```