### PR TITLE
New comment on v0-80-0-stable from Arm

### DIFF
--- a/comments/v0-80-0-stable/entry1751635292499-r7ndi8tgvsc.json
+++ b/comments/v0-80-0-stable/entry1751635292499-r7ndi8tgvsc.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Love the payees system, and the mass editing made adding payees to all my transactions super simple. \n\nWould love a preference/option to have the app always switch to the current month when opening, because I ALWAYS forget to switch when the new month starts and then end up having to edit a dozen transactions to the correct date when I finally notice. \n\nThat would be a nice quality of life feature.",
+  "email": "9830e8e309e3fe8b3d369f5e013b0a91",
+  "name": "Arm",
+  "subdir": "v0-80-0-stable",
+  "_id": "1751635292499-r7ndi8tgvsc",
+  "date": 1751635292499
+}


### PR DESCRIPTION
New comment on `v0-80-0-stable`:

```
{
  "name": "Arm",
  "message": "Love the payees system, and the mass editing made adding payees to all my transactions super simple. \n\nWould love a preference/option to have the app always switch to the current month when opening, because I ALWAYS forget to switch when the new month starts and then end up having to edit a dozen transactions to the correct date when I finally notice. \n\nThat would be a nice quality of life feature.",
  "date": 1751635292499
}
```